### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can find more examples here:
   - [Basic usage with TypeScript and React using body strategy][basic-typescript-react-json] (JSON)
   - [Advanced usage with TypeScript, React template and custom local fonts][advanced-typescript-react]
 
-_the `example/` directory contains simple [Next.js][next-homepage] application implementing `next-api-og-image` . To fully explore examples implemented in it by yourself - simply do `npm link && cd examples && npm i && npm run dev` then navigate to http://localhost:3000/_
+_the `example/` directory contains simple [Next.js][next-homepage] application implementing `next-api-og-image` . To fully explore examples implemented in it by yourself - simply do `npm link && cd example && npm i && npm run dev` then navigate to http://localhost:3000/_
 
 ## Basic usage and explaination
 


### PR DESCRIPTION
I tried to run this command from the README: 
`npm link && cd examples && npm i && npm run dev`

And it failed:
<img width="693" alt="Снимок экрана 2021-11-24 в 15 48 06" src="https://user-images.githubusercontent.com/15171036/143250281-87d7e861-b40f-482e-b8d6-9418ed6bad1b.png">

 There is no `examples` folder in your repo. It's `example` 😉